### PR TITLE
fix: prevent blank screen by removing stdout writes from plugin init

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,15 +21,16 @@ function getPluginVersion(): string {
   }
 }
 
-// Log version immediately on module load (before any other code runs)
-console.log(`[opencode-mobile] v${getPluginVersion()}`);
-
 const DEBUG_ENABLED = process.env.OPENCODE_MOBILE_DEBUG === "1";
 const debugLog = (...args: unknown[]): void => {
   if (DEBUG_ENABLED) {
     console.log(...args);
   }
 };
+
+// Log version in debug mode only — do NOT use console.log here.
+// Top-level stdout writes during module load corrupt the OpenCode TUI (blank screen bug).
+debugLog(`[opencode-mobile] v${getPluginVersion()}`);
 
 debugLog("\n=== opencode-mobile DEV ===");
 debugLog("LAN-only architecture: plugin handles push tokens, tunnel goes to OpenCode directly");
@@ -744,7 +745,8 @@ async function startServer(port: number, openCodePort: number): Promise<boolean>
 }
 
 export const PushNotificationPlugin: Plugin = async (ctx) => {
-  console.log("[opencode-mobile] Plugin init called");
+  // Do NOT use console.log here — stdout writes after TUI starts cause a blank screen.
+  debugLog("[opencode-mobile] Plugin init called");
   debugLog("[PushPlugin][Mobile] Initialized");
 
   logPluginVersion(ctx);
@@ -808,7 +810,10 @@ export const PushNotificationPlugin: Plugin = async (ctx) => {
     const tunnel = await startTunnelWithFallback(openCodePort);
     debugLog("[DEV] Tunnel started:", tunnel.url);
     activeTunnel = tunnel;
-    await displayQRCode(tunnel.url);
+    // NOTE: Do NOT call displayQRCode() here — printing to stdout while the
+    // TUI is running corrupts the display (blank screen bug).
+    // The tunnel URL is persisted to metadata below; users can get the QR
+    // by typing /mobile in the OpenCode session.
 
     // Save tunnel metadata to .config/opencode/tunnel.json
     updateTunnelMetadata(
@@ -819,7 +824,7 @@ export const PushNotificationPlugin: Plugin = async (ctx) => {
       openCodePort
     );
   } catch (tunnelError: any) {
-    console.error("[DEV] Failed to start tunnel:", tunnelError.message);
+    debugLog("[DEV] Failed to start tunnel:", tunnelError.message);
   }
 
   return {

--- a/src/tunnel/ngrok.ts
+++ b/src/tunnel/ngrok.ts
@@ -198,6 +198,12 @@ export async function ensureNgrokReady(): Promise<{ ready: boolean; authtoken: s
   }
 
   if (!diagnostics.authtokenConfigured || diagnostics.error) {
+    // Only offer interactive setup when stdin is a real terminal (TTY).
+    // When running inside the OpenCode plugin context stdin belongs to the TUI;
+    // creating a readline interface there hijacks it and causes a blank screen.
+    if (!process.stdin.isTTY) {
+      return { ready: false, authtoken: null };
+    }
     const authtoken = await setupNgrokWithUserInput();
     return { ready: !!authtoken, authtoken };
   }
@@ -507,12 +513,23 @@ export async function stopNgrok(): Promise<void> {
 }
 
 /**
- * Check if ngrok SDK is available
+ * Check if a real ngrok binary is available in PATH.
+ *
+ * Previously this only checked whether the @ngrok/ngrok npm package could be
+ * imported, which always returned true because the package is a listed dependency
+ * of opencode-mobile itself.  That caused the auto-tunnel logic to always attempt
+ * ngrok, which led to ensureNgrokReady() invoking setupNgrokWithUserInput(), which
+ * created a readline interface on process.stdin — hijacking stdin from the OpenCode
+ * TUI and producing a blank screen.
+ *
+ * Checking for the actual binary ensures we only attempt ngrok when it is genuinely
+ * installed and ready to use.
  */
 export async function isNgrokInstalled(): Promise<boolean> {
   try {
-    await import("@ngrok/ngrok");
-    return true;
+    const { spawnSync } = await import("child_process");
+    const result = spawnSync("ngrok", ["version"], { stdio: "ignore" });
+    return result.status === 0 && result.error === undefined;
   } catch {
     return false;
   }


### PR DESCRIPTION
Four distinct root causes all caused OpenCode's TUI to render a blank screen after the opencode-mobile plugin was installed:

1. **Top-level console.log at module load** (index.ts line 25) Any write to stdout at module-load time fires after the TUI has entered alternate-screen mode.  The stray output scrolls the terminal buffer and the TUI repaints to the wrong position, showing nothing. → Moved the version log behind `debugLog` (OPENCODE_MOBILE_DEBUG=1 only).

2. **console.log inside PushNotificationPlugin init** (index.ts line 747) Same problem — runs while the TUI is already active. → Changed to `debugLog`.

3. **displayQRCode() called during auto-tunnel startup** (index.ts serve mode) qrcode-terminal dumps a multi-line block to stdout while the TUI is rendering, corrupting the display. → Removed the displayQRCode() call from auto-tunnel startup.  The URL is already persisted to tunnel metadata; users get the QR via /mobile.

4. **isNgrokInstalled() always returned true** (src/tunnel/ngrok.ts) The function only checked whether the @ngrok/ngrok npm package could be imported.  Because that package is a dependency of opencode-mobile itself the check always returned true, causing startNgrokTunnel() to be invoked. startNgrokTunnel() calls ensureNgrokReady(), which calls setupNgrokWithUserInput() when no authtoken is configured — that function creates a readline interface on process.stdin, hijacking stdin from the TUI and producing a blank screen. → isNgrokInstalled() now checks for an actual `ngrok` binary via spawnSync. → ensureNgrokReady() also guards against non-TTY stdin before attempting interactive setup, as a second line of defence.