### PR TITLE
fix: add .js extensions to relative imports so the plugin loads under ESM

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -40,15 +40,15 @@ import http from "http";
 
 import { tool } from "@opencode-ai/plugin";
 import type { Plugin } from "@opencode-ai/plugin";
-import type { PushToken } from "./src/push";
-import { formatNotification } from "./src/push/formatter";
-import { sendPush } from "./src/push/sender";
-import { loadTokens, saveTokens } from "./src/push/token-store";
-import { startLocaltunnel, stopLocaltunnel, getLocaltunnelUrl } from "./src/tunnel/localtunnel";
-import { displayQRCode, generateQRCodeAscii, generateQRCodeAsciiPlain } from "./src/tunnel/qrcode";
-import { startNgrokTunnel, stopNgrokTunnel, isNgrokInstalled } from "./src/tunnel/ngrok";
-import { startCloudflareTunnel, stopCloudflareTunnel, getCloudflareUrl, isCloudflareInstalled } from "./src/tunnel/cloudflare";
-import { updateTunnelMetadata, clearTunnelMetadata, loadTunnelMetadata } from "./src/tunnel/metadata";
+import type { PushToken } from "./src/push/index.js";
+import { formatNotification } from "./src/push/formatter.js";
+import { sendPush } from "./src/push/sender.js";
+import { loadTokens, saveTokens } from "./src/push/token-store.js";
+import { startLocaltunnel, stopLocaltunnel, getLocaltunnelUrl } from "./src/tunnel/localtunnel.js";
+import { displayQRCode, generateQRCodeAscii, generateQRCodeAsciiPlain } from "./src/tunnel/qrcode.js";
+import { startNgrokTunnel, stopNgrokTunnel, isNgrokInstalled } from "./src/tunnel/ngrok.js";
+import { startCloudflareTunnel, stopCloudflareTunnel, getCloudflareUrl, isCloudflareInstalled } from "./src/tunnel/cloudflare.js";
+import { updateTunnelMetadata, clearTunnelMetadata, loadTunnelMetadata } from "./src/tunnel/metadata.js";
 
 function logPluginVersion(ctx: Parameters<Plugin>[0]): void {
   const client = (ctx as any)?.client;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,9 @@
       },
       "bin": {
         "opencode-mobile": "bin/audit",
-        "opencode-mobile-qr": "bin/qr"
+        "opencode-mobile-qr": "bin/qr",
+        "opencode-mobile-tunnel-setup": "dist/src/cli/tunnel-setup.js",
+        "opencode-mobile-uninstall": "bin/uninstall"
       },
       "devDependencies": {
         "@types/localtunnel": "^2.0.4",

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -2,4 +2,4 @@
  * Proxy module barrel export
  */
 
-export * from "./types";
+export * from "./types.js";

--- a/src/push/formatter.ts
+++ b/src/push/formatter.ts
@@ -2,9 +2,9 @@
  * Notification formatting utilities
  */
 
-import type { Notification, NotificationEvent, PluginContext } from "./types";
-import { truncate } from "./token-store";
-import { loadFilterConfig, shouldFilterSession } from "./filters";
+import type { Notification, NotificationEvent, PluginContext } from "./types.js";
+import { truncate } from "./token-store.js";
+import { loadFilterConfig, shouldFilterSession } from "./filters.js";
 
 const DEBUG_ENABLED = process.env.OPENCODE_MOBILE_DEBUG === "1";
 const debugLog = (...args: unknown[]): void => {

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -2,8 +2,8 @@
  * Push notification module barrel export
  */
 
-export * from "./types";
-export * from "./token-store";
-export * from "./formatter";
-export * from "./sender";
-export * from "./notification-handler";
+export * from "./types.js";
+export * from "./token-store.js";
+export * from "./formatter.js";
+export * from "./sender.js";
+export * from "./notification-handler.js";

--- a/src/push/sender.ts
+++ b/src/push/sender.ts
@@ -2,8 +2,8 @@
  * Push notification sender
  */
 
-import type { Notification } from "./types";
-import { loadTokens, saveTokens } from "./token-store";
+import type { Notification } from "./types.js";
+import { loadTokens, saveTokens } from "./token-store.js";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
 

--- a/src/push/token-store.ts
+++ b/src/push/token-store.ts
@@ -4,7 +4,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import type { PushToken } from "./types";
+import type { PushToken } from "./types.js";
 
 const CONFIG_DIR = path.join(process.env.HOME || "", ".config/opencode");
 const TOKEN_FILE = path.join(CONFIG_DIR, "push-tokens.json");

--- a/src/tunnel/cloudflare.ts
+++ b/src/tunnel/cloudflare.ts
@@ -12,7 +12,7 @@ import { spawn, ChildProcess, execSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import type { TunnelConfig, TunnelInfo } from "./types";
+import type { TunnelConfig, TunnelInfo } from "./types.js";
 
 // Export types for external use
 export type { TunnelConfig, TunnelInfo };

--- a/src/tunnel/index.ts
+++ b/src/tunnel/index.ts
@@ -3,24 +3,24 @@
  */
 
 import * as fs from "fs";
-import type { TunnelConfig, TunnelInfo, TunnelDetails } from "./types";
+import type { TunnelConfig, TunnelInfo, TunnelDetails } from "./types.js";
 import { 
   startNgrokTunnel, 
   stopNgrokTunnel, 
   diagnoseNgrok, 
   ensureNgrokReady 
-} from "./ngrok";
+} from "./ngrok.js";
 import { 
   startLocaltunnel, 
   stopLocaltunnel, 
   getLocaltunnelUrl 
-} from "./localtunnel";
+} from "./localtunnel.js";
 import { 
   startCloudflareTunnel, 
   stopCloudflareTunnel, 
   getCloudflareUrl 
-} from "./cloudflare";
-import { displayQRCode } from "./qrcode";
+} from "./cloudflare.js";
+import { displayQRCode } from "./qrcode.js";
 
 let currentTunnel: TunnelInfo | null = null;
 

--- a/src/tunnel/localtunnel.ts
+++ b/src/tunnel/localtunnel.ts
@@ -8,7 +8,7 @@
  */
 
 import localtunnel from "localtunnel";
-import type { TunnelConfig, TunnelInfo } from "./types";
+import type { TunnelConfig, TunnelInfo } from "./types.js";
 
 // Export the type for external use
 export type { TunnelConfig, TunnelInfo };

--- a/src/tunnel/ngrok.ts
+++ b/src/tunnel/ngrok.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { spawn } from "child_process";
 import * as ngrok from "@ngrok/ngrok";
-import type { TunnelConfig, TunnelInfo, NgrokDiagnostics } from "./types";
+import type { TunnelConfig, TunnelInfo, NgrokDiagnostics } from "./types.js";
 
 let ngrokInstance: any = null;
 let ngrokSession: any = null;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,4 +2,4 @@
  * Utilities barrel export
  */
 
-export * from "./port";
+export * from "./port.js";


### PR DESCRIPTION
## Problem

On OpenCode 1.14.33, the published `opencode-mobile` plugin fails to load and never starts a tunnel. The OpenCode log shows:

```
ERROR service=plugin path=opencode-mobile@latest
  error=Cannot find module '.../dist/src/push/formatter'
  imported from '.../dist/index.js'
  failed to load plugin
```

This is why users see `No tunnel URL found` from `/mobile` — the plugin never actually loads.

## Root cause

`tsconfig.json` uses `"moduleResolution": "bundler"`, which allows the source to omit file extensions on relative imports and emits them **unchanged** (e.g. `import { formatNotification } from "./src/push/formatter"`). OpenCode loads plugins with strict ESM resolution, which requires explicit `.js` extensions, so every extensionless relative specifier throws `ERR_MODULE_NOT_FOUND` and the whole plugin fails to load.

`dist/src/push/formatter.js` exists in the published package — it just can't be resolved without the extension.

The `src/cli/*` files already use `.js` extensions; only the plugin runtime graph (reachable from `index.ts`) was affected.

## Fix

Add `.js` extensions to all relative imports in the plugin runtime graph:

- `index.ts`
- `src/push/{index,formatter,sender,token-store}.ts`
- `src/tunnel/{index,cloudflare,localtunnel,ngrok}.ts`
- `src/utils/index.ts`
- `src/proxy/index.ts`

11 files, 30 lines. No behavior changes — only import specifiers.

## Verification

After `npm run build`, loaded the built plugin into OpenCode 1.14.33 via the local plugins dir. The plugin now initializes cleanly (no module error), the serve-mode gate passes, the Cloudflare tunnel starts, and the QR/URL are generated:

```
[opencode-mobile] v1.4.0
[PushPlugin][Mobile] Initialized
[PushPlugin] isServeMode: true
[Tunnel] Auto-selecting Cloudflare (most secure)...
[Cloudflared] URL: https://<...>.trycloudflare.com
```

## Suggested follow-up (not in this PR)

Consider switching `tsconfig.json` to `"moduleResolution": "nodenext"` so extensionless relative imports become compile-time errors and this class of bug can't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
