### PR TITLE
feat: add OPENCODE_MOBILE_FORCE_TUNNEL escape hatch for argv gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ https://your-tunnel-url.ngrok.io
 |----------|-------------|---------|
 | `TUNNEL_PROVIDER` | Tunnel provider (`auto`, `ngrok`, `cloudflare`, `localtunnel`) | `auto` |
 | `OPENCODE_MOBILE_DEBUG` | Enable debug logging (`1` to enable) | disabled |
+| `OPENCODE_MOBILE_FORCE_TUNNEL` | Bypass the `opencode serve` argv gate and always start a tunnel (`1` to enable). Use when the plugin logs `skipping (not in 'serve' mode)` but you *know* you're in a session that should tunnel — e.g. some OpenCode >= 1.17.x TUI entrypoints strip the `serve` token from `process.argv`. | disabled |
 | `OPENCODE_PORT` | Local server port | `3000` |
 
 ### Tunnel Providers

--- a/index.ts
+++ b/index.ts
@@ -757,19 +757,26 @@ export const PushNotificationPlugin: Plugin = async (ctx) => {
   //   proxy for "serve mode" and will cause ngrok/localtunnel to start unexpectedly.
   // - Bun preserves the OpenCode subcommand tokens in `process.argv` (serve/debug/wait/etc),
   //   so we gate on the presence of the literal `serve` token.
+  //
+  // ESCAPE HATCH: Some OpenCode versions/entrypoints strip subcommand tokens from
+  // `process.argv` (observed on opencode >= 1.17.x when running the TUI). The gate then
+  // never trips and `/mobile` reports "No tunnel URL found." Users can set
+  // `OPENCODE_MOBILE_FORCE_TUNNEL=1` to bypass the gate and always start a tunnel.
   const hasServerUrl = !!(ctx as any)?.serverUrl;
   const isAttachMode = process.argv.includes("attach");
   const isServeMode = process.argv.includes("serve") && !isAttachMode;
+  const forceTunnel = process.env.OPENCODE_MOBILE_FORCE_TUNNEL === "1";
 
   debugLog("[PushPlugin] hasServerUrl:", hasServerUrl);
   debugLog("[PushPlugin] isAttachMode:", isAttachMode);
   debugLog("[PushPlugin] isServeMode:", isServeMode);
+  debugLog("[PushPlugin] forceTunnel:", forceTunnel);
   debugLog("[PushPlugin] process.argv:", process.argv.join(", "));
 
-  if (!isServeMode) {
+  if (!isServeMode && !forceTunnel) {
     console.log(
       "[opencode-mobile] Plugin init OK; skipping (not in 'serve' mode). " +
-        "Run: opencode serve ...",
+        "Run: opencode serve ... — or set OPENCODE_MOBILE_FORCE_TUNNEL=1 to override.",
     );
     return {
       tool: {


### PR DESCRIPTION
## Summary

Adds an environment variable escape hatch — `OPENCODE_MOBILE_FORCE_TUNNEL=1` — that bypasses the `process.argv.includes("serve")` gate in `index.ts:762` so users on OpenCode versions where the gate never trips can still auto-start a tunnel.

## The problem

The plugin currently gates its LAN server + tunnel startup on:

```ts
const isServeMode = process.argv.includes("serve") && !isAttachMode;
if (!isServeMode) { /* skip tunnel */ }
```

The comment on lines 758–759 explains the intent:

> Bun preserves the OpenCode subcommand tokens in `process.argv` (serve/debug/wait/etc), so we gate on the presence of the literal `serve` token.

That premise no longer holds on current OpenCode releases. Tested on `opencode` **1.17.13**, running either `opencode run "…"` (headless) or a normal TUI session:

```
[PushPlugin] process.argv: bun, /$bunfs/root/src/index.js, run, hi
[PushPlugin] isServeMode: false
[opencode-mobile] Plugin init OK; skipping (not in 'serve' mode). Run: opencode serve ...
```

`process.argv[1]` is now Bun's virtual-FS entry (`/$bunfs/root/src/index.js`) rather than a path containing the subcommand, and the `serve` token is stripped. The gate is never true from the plugin's point of view, so the tunnel never starts and `/mobile` responds with **"No tunnel URL found."**

Additionally, `opencode serve` (headless mode) does **not** load JS plugins at all in this version — verified by running `opencode serve` with `OPENCODE_MOBILE_DEBUG=1` and observing no `[opencode-mobile]` log lines. So the "just run `opencode serve`" hint in the skip message doesn't recover the user either.

## The fix

Add an env var override that keeps the existing default behaviour but lets users opt in to always starting a tunnel:

```ts
const forceTunnel = process.env.OPENCODE_MOBILE_FORCE_TUNNEL === "1";
if (!isServeMode && !forceTunnel) { /* skip */ }
```

- Default behaviour unchanged when the env var is unset — the argv gate still guards against accidental tunnel starts on `opencode debug wait` and similar lifecycles where `ctx.serverUrl` is set but a tunnel is undesired.
- Users on affected OpenCode versions set `OPENCODE_MOBILE_FORCE_TUNNEL=1` (once, in their shell profile) and the plugin resumes working.
- Skip-path log message updated to hint at the new env var so users find it without needing to open source.

## Verification

Tested locally on macOS + opencode 1.17.13 + Node v26.3.0 + cloudflared 2026.6.1:

**Without env var** (default preserved):
\`\`\`
[PushPlugin] isServeMode: false
[PushPlugin] forceTunnel: false
[opencode-mobile] Plugin init OK; skipping (not in 'serve' mode). …
\`\`\`
tunnel.json not written, /mobile → \"No tunnel URL found.\" (matches current behaviour.)

**With OPENCODE_MOBILE_FORCE_TUNNEL=1 TUNNEL_PROVIDER=cloudflare:**
\`\`\`
[PushPlugin] forceTunnel: true
[DEV] Auto-starting tunnel...
[Tunnel] Using specific provider: cloudflare
[Cloudflared] URL: https://learning-contributing-russell-letters.trycloudflare.com
[TunnelMetadata] Saved to: /Users/oliver/.config/opencode/tunnel.json
\`\`\`
tunnel.json correctly populated, /mobile now returns a QR code.

## Files changed

- \`index.ts\` — read \`OPENCODE_MOBILE_FORCE_TUNNEL\`, extend gate, add debug log, expanded comment explaining the escape hatch, updated skip-path message.
- \`README.md\` — new row in the Environment Variables table documenting the flag and when to reach for it.

## Notes / follow-ups

- If you'd rather flip the default (always start a tunnel; opt-out via env), I'm happy to rework — but keeping opt-in preserves existing behaviour and is safest to merge.
- Longer-term the argv sniff is fragile; a \`ctx\`-provided signal from OpenCode's plugin loader (e.g. \`ctx.mode: \"serve\" | \"run\" | \"tui\"\`) would be a better contract, but that requires an upstream OpenCode change.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` succeeds
- [x] Verified skip path unchanged when env var absent
- [x] Verified tunnel starts + tunnel.json written when env var set
- [ ] Reviewer to sanity-check log wording & README phrasing